### PR TITLE
#24 tronWeb.utils.promiseInjector no longer exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Transaction from 'lib/core/Transaction';
 import TronWebPlugin from 'lib/plugins/TronWebPlugin';
 import APIClient from 'lib/apis/APIClient';
 import validator from 'utils/Validator';
+import injectpromise from 'injectpromise';
 
 let utils;
 let experimental;
@@ -25,7 +26,7 @@ export default class TronGrid {
         this.transaction = new Transaction(this);
         this.apiClient = new APIClient(this);
         this.validator = new validator(this);
-        this.injectPromise = this.tronWeb.utils.promiseInjector(this);
+        this.injectPromise = new injectpromise(this);
 
         this.experimental = undefined;
     }

--- a/src/lib/core/Base.js
+++ b/src/lib/core/Base.js
@@ -10,7 +10,7 @@ class Base {
 
         this.tronGrid = tronGrid;
         this.tronWeb = tronGrid.tronWeb;
-        this.injectPromise = this.tronWeb.utils.promiseInjector(this);
+        this.injectPromise = new injectpromise(this);
         this.apiNode = this.tronWeb.eventServer;
         this.utils = this.tronWeb.utils;
         this.validator = new validator(tronGrid);


### PR DESCRIPTION
TronGrid JS is not compatible with TronWeb since the promiseInjector was removed and replaced with injectpromise package as seen here: TRON-US/tronweb@6c07657